### PR TITLE
Migration from calypso

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -33,4 +33,6 @@ jobs:
         run: ./.github/scripts/check_version.sh
       - name: Build and Publish
         working-directory: .
-        run: ./gradlew build test publish --info --stacktrace
+        run: |
+          ./gradlew setSnapshot
+          ./gradlew build test publish --info --stacktrace

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -26,13 +26,19 @@ jobs:
       - name: Install gpg secret key
         run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
-          gpg --pinentry-mode loopback --passphrase "${{ secrets.OSSRH_GPG_SECRET_PASSWORD }}" --export-secret-key 568FD16F857171A0EC6D2C40742C84722FD2B235 > ~/.gradle/maven-central.gpg
+          gpg --pinentry-mode loopback --passphrase "${{ secrets.OSSRH_GPG_SECRET_PASSWORD }}" --export-secret-key ${{ secrets.OSSRH_GPG_KEY_ID }} > ~/.gradle/maven-central.gpg
           gpg --list-secret-keys --keyid-format LONG
       - name: Check version
         working-directory: .
         run: ./.github/scripts/check_version.sh $(echo "${{ github.ref }}" | sed -e "s,^refs/tags/,,")
       - name: Build and Publish
         working-directory: .
+        env:
+          SIGNING_KEY_ID: ${{ secrets.OSSRH_GPG_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.OSSRH_GPG_SECRET_PASSWORD }}
+          SIGNING_SECRET_KEY_RING_FILE: ~/.gradle/maven-central.gpg
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         run: |
           ./gradlew setVersion -P version=$(echo "${{ github.ref }}" | sed -e "s,^refs/tags/,,")
-          ./gradlew build test release --info --stacktrace
+          ./gradlew build test publish --info --stacktrace

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ local.properties
 # Gradle
 .gradle/
 build*/
-LICENSE_HEADER
 
 # Eclipse
 .classpath

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to "Keyple Plugin CNA Famoco SE Communication Java Lib" implementation
+# Contributing to "Keyple Plugin SE Communication Lib" implementation
 
 Thanks for your interest in this project.
 
 ## Contributing
 
-1. [Fork](https://help.github.com/articles/fork-a-repo) the [calypsonet/keyple-plugin-cna-famoco-se-communication-java-lib](https://github.com/calypsonet/keyple-plugin-cna-famoco-se-communication-java-lib) repository
+1. [Fork](https://help.github.com/articles/fork-a-repo) the [Famoco/keyple-plugin-se-communication-lib](https://github.com/Famoco/keyple-plugin-se-communication-lib) repository
 2. Clone repository: `git clone https://github.com/[your_github_username]/keyple-plugin-cna-famoco-se-communication-java-lib.git`
 3. Create your feature branch: `git checkout -b my-new-feature`
 4. Make your changes

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,0 +1,11 @@
+/* **************************************************************************************
+ * Copyright (c) $YEAR Calypso Networks Association https://calypsonet.org/
+ *
+ * See the NOTICE file(s) distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License 2.0 which is available at http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ************************************************************************************** */

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,8 +1,8 @@
-# Notices for "Keyple Plugin CNA Famoco SE Communication Java Lib" Java implementation
+# Notices for "Keyple Plugin SE Communication Lib" Java implementation
 
-This content is produced and maintained by Calypso Networks Association.
+This content was produced by Calypso Networks Association and is maintained by Famoco.
 
-More information can be found on [calypsonet.org](http://calypsonet.org).
+More information can be found on [calypsonet.org](http://calypsonet.org) and [famoco.com](https://famoco.com).
 
 ## Trademarks
 

--- a/PUBLISHERS.yml
+++ b/PUBLISHERS.yml
@@ -1,7 +1,7 @@
-url: https://github.com/calypsonet/keyple-plugin-cna-famoco-se-communication-java-lib
+url: https://github.com/Famoco/keyple-plugin-se-communication-lib
 organization:
-  name: Calypso Networks Association
-  url: https://calypsonet.org/
+  name: Famoco
+  url: https://famoco.com/
 licenses:
   - name: Eclipse Public License - v 2.0
     url: https://www.eclipse.org/legal/epl-2.0/
@@ -9,10 +9,12 @@ licenses:
 developers:
   - name: Calypso Networks Association Technical Team
     email: support-dev@calypsonet.org
+  - name: Famoco Mobile Team
+    email: support@famoco.com
 scm:
-  connection: scm:git:git://github.com/calypsonet/keyple-plugin-cna-famoco-se-communication-java-lib.git
-  developerConnection: scm:git:https://github.com/calypsonet/keyple-plugin-cna-famoco-se-communication-java-lib.git
-  url: https://github.com/calypsonet/keyple-plugin-cna-famoco-se-communication-java-lib
+  connection: scm:git:git@github.com:Famoco/keyple-plugin-se-communication-lib.git
+  developerConnection: scm:git:https://github.com/Famoco/keyple-plugin-se-communication-lib.git
+  url: https://github.com/Famoco/keyple-plugin-se-communication-lib
 ciManagement:
   system: GitHub Actions
-  url: https://github.com/calypsonet/keyple-plugin-cna-famoco-se-communication-java-lib/actions
+  url: https://github.com/Famoco/keyple-plugin-se-communication-lib/actions

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# Keyple Plugin CNA Famoco SE Communication Java Library
+# Keyple Plugin SE Communication Library
 
 ## Overview
 
-The **Keyple Plugin CNA Famoco SE Communication Java Library** is an add-on to allow an application using Keyple to interact with Famoco terminals.
+The **Keyple Plugin SE Communication Library** is an add-on to allow an application using Keyple to interact with Famoco terminals.
 
 The current version is based on Famoco's native SE Communication library (SeCommunicaton Library v1.7.0.)
 
-Should be compatible with FX100, FX200 and FC300 series.
+Should be compatible with FX100, FX200, FX205 and FX300 series.
 
 ## Examples
 
 An example of implementation is available in the **example-app** folder.
 
-This Android application is using the Keyple Famoco plugin and Keyple Android NFC plugin, allowing to illustrate multiple Calypso use cases.
+This Android application is using the Keyple Famoco SE communication lib plugin and Keyple Android NFC plugin, allowing to illustrate multiple Calypso use cases.
 
 ## About the source code
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,8 +56,8 @@ tasks {
     }
     sonarqube {
         properties {
-            property("sonar.projectKey", "eclipse_" + project.name)
-            property("sonar.organization", "eclipse")
+            property("sonar.projectKey", "Famoco_keyple-plugin-se-communication-lib")
+            property("sonar.organization", "famoco")
             property("sonar.host.url", "https://sonarcloud.io")
             property("sonar.login", System.getenv("SONAR_LOGIN"))
             System.getenv("BRANCH_NAME")?.let {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("org.sonarqube") version "3.1"
     id("org.jetbrains.dokka") version "1.4.32"
 }
+
 buildscript {
     val kotlinVersion: String by project
     repositories {
@@ -17,21 +18,16 @@ buildscript {
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath("com.android.tools.build:gradle:4.1.3")
-        classpath("org.eclipse.keyple:keyple-gradle:0.2.+") { isChanging = true }
     }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 //  APP CONFIGURATION
 ///////////////////////////////////////////////////////////////////////////////
-allprojects{
-    group = "org.calypsonet.keyple"
+allprojects {
     repositories {
-        mavenLocal()
-        maven(url = "https://repo.eclipse.org/service/local/repositories/maven_central/content")
+        maven (url = "https://s01.oss.sonatype.org/content/repositories/snapshots" )
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
-        maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots")
         google()
     }
 }

--- a/famoco-plugin/build.gradle.kts
+++ b/famoco-plugin/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.konan.properties.suffix
+import org.jetbrains.kotlin.util.suffixIfNot
+
 ///////////////////////////////////////////////////////////////////////////////
 //  GRADLE CONFIGURATION
 ///////////////////////////////////////////////////////////////////////////////
@@ -7,6 +10,82 @@ plugins {
     kotlin("android.extensions")
     id("org.jetbrains.dokka")
     id("com.diffplug.spotless")
+}
+
+ext {
+    val pomArtifactId by extra("keyple-plugin-se-communication-lib")
+    val pomDescription by extra("The Keyple Plugin SE Communication Library is an add-on to allow an application using" +
+                " Keyple to interact with Famoco terminals.")
+    val pomName by extra("keyple-plugin-se-communication-lib")
+    val moduleTitle by extra("Keyple Plugin SE Communication Library")
+    val pomLicenseName by extra("https://www.eclipse.org/legal/epl-2.0/")
+    val pomLicenseURL by extra("http://www.apache.org/licenses/LICENSE-2.0.txt")
+    val pomUrl by extra("https://github.com/Famoco/keyple-plugin-se-communication-lib")
+    val pomOrgName by extra("Famoco")
+    val pomOrgUrl by extra("https://famoco.com")
+    val pomScmUrl by extra("https://github.com/Famoco/keyple-plugin-se-communication-lib")
+    val pomScmConnection by extra("scm:git:git://github.com/Famoco/keyple-plugin-se-communication-lib.git")
+    val pomScmdeveloperConnection by extra("scm:git:https://github.com/Famoco/keyple-plugin-se-communication-lib.git")
+    val pomDevelopersName by extra("Famoco Mobile team")
+    val pomDevelopersemail by extra("support@famoco.com")
+}
+
+/**
+ * Sets version inside the gradle.properties file
+ * Usage: ./gradlew setVersion -P version=1.0.0
+ */
+tasks.register("setVersion") {
+    val backupFile = rootProject.file("gradle.properties.bak")
+    backupFile.delete()
+    val propsFile = rootProject.file("gradle.properties")
+    propsFile.renameTo(backupFile)
+
+    var version = rootProject.version as String
+    version = version.removeSuffix("-SNAPSHOT")
+    propsFile.printWriter().use {
+        var versionApplied = false
+        backupFile.readLines()
+            .forEach { line ->
+                if (line.matches(Regex("version\\s*=.*"))) {
+                    versionApplied = true
+                    it.println("version = $version")
+                } else {
+                    it.println(line)
+                }
+            }
+        if (!versionApplied) {
+            it.println("version = $version")
+        }
+    }
+
+    println("Setting new version for ${rootProject.name} to $version")
+}
+
+tasks.register("setSnapshot") {
+    val backupFile = rootProject.file("gradle.properties.bak")
+    backupFile.delete()
+    val propsFile = rootProject.file("gradle.properties")
+    propsFile.renameTo(backupFile)
+
+    var version = rootProject.version as String
+    version = version.suffixIfNot("-SNAPSHOT")
+    propsFile.printWriter().use {
+        var versionApplied = false
+        backupFile.readLines()
+            .forEach { line ->
+                if (line.matches(Regex("version\\s*=.*"))) {
+                    versionApplied = true
+                    it.println("version = $version")
+                } else {
+                    it.println(line)
+                }
+            }
+        if (!versionApplied) {
+            it.println("version = $version")
+        }
+    }
+
+    println("Setting new version for ${rootProject.name} to $version")
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -113,6 +192,7 @@ dependencies {
 ///////////////////////////////////////////////////////////////////////////////
 //  TASKS CONFIGURATION
 ///////////////////////////////////////////////////////////////////////////////
+
 tasks {
     dokkaHtml.configure {
         dokkaSourceSets {
@@ -124,5 +204,4 @@ tasks {
         }
     }
 }
-apply(plugin = "org.eclipse.keyple") // To do last
-
+apply(from = "maven.gradle")  // To do last

--- a/famoco-plugin/maven.gradle
+++ b/famoco-plugin/maven.gradle
@@ -1,0 +1,83 @@
+apply plugin: 'maven-publish'
+apply plugin: 'org.jetbrains.dokka'
+apply plugin: 'kotlin-android'
+apply plugin: 'signing'
+
+ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
+ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+    from android.sourceSets.main.kotlin.srcDirs
+}
+
+tasks.withType(dokkaHtml.getClass()).configureEach {
+    pluginsMapConfiguration.set(
+            ["org.jetbrains.dokka.base.DokkaBase": """{ "separateInheritedMembers": true}"""]
+    )
+}
+
+task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
+    archiveClassifier.set('kdoc')
+    from dokkaJavadoc.outputDirectory
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            mavenRelease(MavenPublication) {
+                groupId = project.group
+                artifactId = project.ext.pomArtifactId
+                version = android.defaultConfig.versionName
+
+                pom {
+                    name = project.ext.pomName
+                    description = project.ext.pomDescription
+                    url = project.ext.pomUrl
+                    licenses {
+                        name = project.ext.pomLicenseName
+                        url = project.ext.pomLicenseURL
+                    }
+                    developers {
+                        developer {
+                            name = project.ext.pomDevelopersName
+                            email = project.ext.pomDevelopersemail
+                        }
+                    }
+                    scm {
+                        connection = project.ext.pomScmConnection
+                        developerConnection = project.ext.pomScmdeveloperConnection
+                        url = project.ext.pomScmUrl
+                    }
+                }
+
+                artifact androidSourcesJar
+                artifact javadocJar
+                artifact("$buildDir/outputs/aar/${archivesBaseName}-${version}.aar")
+            }
+        }
+        repositories {
+            maven {
+                credentials {
+                    username = ossrhUsername
+                    password = ossrhPassword
+                }
+                def releasesRepoUrl = "https://s01.oss.sonatype.org/content/repositories/release"
+                def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            }
+        }
+    }
+
+    signing {
+        sign publishing.publications.mavenRelease
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-group = org.calypsonet.keyple
-title = Keyple Plugin CNA Famoco SE Communication Java Lib
-description = Keyple add-on to manage Famoco SE Communication readers
 version = 2.0.3
-archivesBaseName = keyple-plugin-cna-famoco-se-communication-java-lib
+group = io.github.famoco
+title = Keyple Plugin SE Communication Lib
+description = Keyple add-on to manage SE Communication readers
+archivesBaseName = keyple-plugin-se-communication-lib
 
 javaSourceLevel = 1.6
 javaTargetLevel = 1.6
@@ -18,5 +18,5 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4608m
 
 javadoc.logo = <span></span>
-javadoc.copyright = Copyright \u00a9 Calypso Networks Association https://calypsonet.org/
+javadoc.copyright = Copyright \u00a9 Famoco https://famoco.com/
 sonatype.url = https://s01.oss.sonatype.org

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 include(":example-app")
 include(":famoco-plugin")
-rootProject.name = "keyple-plugin-cna-famoco-se-communication-java-lib"
+rootProject.name = "keyple-plugin-se-communication-lib"
 
 // Fix resolution of dependencies with dynamic version in order to use SNAPSHOT first when available.
 // See explanation here : https://docs.gradle.org/6.8.3/userguide/single_versions.html


### PR DESCRIPTION
Following the fork from the Calypso Github, those changes adapte the build script and the CI to match the Famoco environment.

Main changes are:
- publication on Maven Central with the Famoco credentials
- removing the dependencies with the Calypso OPS Maven plugin
- new link with the Famoco SonarCloud account
- Rewording some documentation to include the Famoco as contributor and maintainer