### PR TITLE
Fix a crash related to the name of the reader protocol

### DIFF
--- a/example-app/src/main/kotlin/org/calypsonet/keyple/plugin/famoco/example/activity/MainActivity.kt
+++ b/example-app/src/main/kotlin/org/calypsonet/keyple/plugin/famoco/example/activity/MainActivity.kt
@@ -38,6 +38,7 @@ import org.eclipse.keyple.core.service.SmartCardServiceProvider
 import org.eclipse.keyple.core.util.HexUtil
 import org.eclipse.keyple.plugin.android.nfc.AndroidNfcPluginFactoryProvider
 import org.eclipse.keyple.plugin.android.nfc.AndroidNfcReader
+import org.eclipse.keyple.plugin.android.nfc.AndroidNfcSupportedProtocols
 import timber.log.Timber
 
 class MainActivity : AbstractExampleActivity() {
@@ -46,7 +47,6 @@ class MainActivity : AbstractExampleActivity() {
   private lateinit var samReader: CardReader
 
   private lateinit var cardSelectionManager: CardSelectionManager
-  private lateinit var contactlessCardProtocol: String
 
   private enum class TransactionType {
     DECREASE,
@@ -82,9 +82,8 @@ class MainActivity : AbstractExampleActivity() {
     //        (poReader as AndroidNfcReader).skipNdefCheck = false
 
     (poReader as ObservableCardReader).addObserver(this)
-    contactlessCardProtocol = "ISO_14443_4_CARD"
     (poReader as ConfigurableCardReader).activateProtocol(
-        contactlessCardProtocol, contactlessCardProtocol)
+        AndroidNfcSupportedProtocols.ISO_14443_4.name, CalypsoClassicInfo.CARD_PROTOCOL)
 
     // Configuration for Sam Reader. Sam access provided by Famoco lib-secommunication
     samReader = samPlugin.getReader(AndroidFamocoReader.READER_NAME)
@@ -182,7 +181,7 @@ class MainActivity : AbstractExampleActivity() {
       val poSelectionRequest = calypsoCardExtensionProvider.createCardSelection()
       poSelectionRequest
           .filterByDfName(CalypsoClassicInfo.AID)
-          .filterByCardProtocol(contactlessCardProtocol)
+          .filterByCardProtocol(CalypsoClassicInfo.CARD_PROTOCOL)
 
       /* Prepare the reading order and keep the associated parser for later use once the
       selection has been made. */

--- a/example-app/src/main/kotlin/org/calypsonet/keyple/plugin/famoco/example/util/CalypsoClassicInfo.kt
+++ b/example-app/src/main/kotlin/org/calypsonet/keyple/plugin/famoco/example/util/CalypsoClassicInfo.kt
@@ -42,7 +42,7 @@ object CalypsoClassicInfo {
   const val eventLog_dataFill = "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCC"
 
   const val RECORD_SIZE = 29
-
+  const val CARD_PROTOCOL = "ISO_14443_4_CARD"
   // Security settings
   const val SAM_PROFILE_NAME = "SAM C1"
 


### PR DESCRIPTION
The name has probably been changed in the
keyple-plugin-android-nfc-java-lib at some point.